### PR TITLE
v1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@
 *.sublime-workspace
 *.idea
 *.vscode
+
+/vendor

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018, go-accepter authors.
+Copyright (c) 2019, go-accepter authors.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ It is similar with GoLang's http.Server.
 * changed Handler.Serve arguments to (ctx, conn) from (conn, closeCh)
 * removed panic recovering for Handler.Serve(...)
 * removed Accepter.ErrorLog
+* removed TCPListenAndServe and TCPListenAndServeTLS
+* added ListenAndServe and ListenAndServeTLS

--- a/README.md
+++ b/README.md
@@ -7,5 +7,7 @@ It is similar with GoLang's http.Server.
 
 ## Changes from v1
 
+* using cancelling context instead of channel
+* changed Handler.Serve arguments to (ctx, conn) from (conn, closeCh)
+* removed panic recovering for Handler.Serve(...)
 * removed Accepter.ErrorLog
-* using context instead of closeCh

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Package accepter provides an Accepter and utilities for net.Listener.
 It is similar with GoLang's http.Server.
 
-## Changes from v1
+## v1.2 changes from v1.0
 
 * using cancelling context instead of channel
 * changed Handler.Serve arguments to (ctx, conn) from (conn, closeCh)

--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ It is similar with GoLang's http.Server.
 * removed Accepter.ErrorLog
 * removed TCPListenAndServe and TCPListenAndServeTLS
 * added ListenAndServe and ListenAndServeTLS
+* added go.mod support

--- a/README.md
+++ b/README.md
@@ -3,4 +3,9 @@
 [![GoDoc](https://godoc.org/github.com/orkunkaraduman/go-accepter?status.svg)](https://godoc.org/github.com/orkunkaraduman/go-accepter)
 
 Package accepter provides an Accepter and utilities for net.Listener.
-It seems like GoLang's http.Server.
+It is similar with GoLang's http.Server.
+
+## Changes from v1
+
+* removed Accepter.ErrorLog
+* using context instead of closeCh

--- a/accepter.go
+++ b/accepter.go
@@ -9,8 +9,8 @@ import (
 	"time"
 )
 
-// An Accepter defines parameters to accept connections. It seems like
-// GoLang's http.Server.
+// An Accepter defines parameters to accept connections.
+// It is similar with GoLang's http.Server.
 type Accepter struct {
 	// Handler to invoke.
 	Handler Handler

--- a/accepter.go
+++ b/accepter.go
@@ -148,10 +148,13 @@ func (a *Accepter) Serve(lis net.Listener) (err error) {
 // a certificate authority, the certFile should be the concatenation of the
 // Accepter's certificate, any intermediates, and the CA's certificate.
 func (a *Accepter) ServeTLS(l net.Listener, certFile, keyFile string) (err error) {
-	config := a.TLSConfig
-	if config == nil {
+	var config *tls.Config
+	if a.TLSConfig != nil {
+		config = a.TLSConfig.Clone()
+	} else {
 		config = &tls.Config{}
 	}
+
 	configHasCert := len(config.Certificates) > 0 || config.GetCertificate != nil
 	if !configHasCert || certFile != "" || keyFile != "" {
 		config.Certificates = make([]tls.Certificate, 1)
@@ -160,6 +163,7 @@ func (a *Accepter) ServeTLS(l net.Listener, certFile, keyFile string) (err error
 			return
 		}
 	}
+
 	tlsListener := tls.NewListener(l, config)
 	return a.Serve(tlsListener)
 }

--- a/accepter.go
+++ b/accepter.go
@@ -113,7 +113,6 @@ func (a *Accepter) TCPListenAndServeTLS(addr string, certFile, keyFile string) e
 // Shutdown method called.
 func (a *Accepter) Serve(lis net.Listener) (err error) {
 	a.lis = lis
-	defer a.lis.Close()
 	a.ctx, a.ctxCancel = context.WithCancel(context.Background())
 	defer a.ctxCancel()
 	a.conns = make(map[net.Conn]struct{})

--- a/accepter.go
+++ b/accepter.go
@@ -33,7 +33,7 @@ type Accepter struct {
 // context's error, otherwise it returns any error returned from closing the
 // Accepter's underlying Listener.
 //
-// When Shutdown is called, Serve, TCPListenAndServe, and TCPListenAndServeTLS
+// When Shutdown is called, Serve, ServeTLS, ListenAndServe, and ListenAndServeTLS
 // immediately return nil. Make sure the program doesn't exit and waits
 // instead for Shutdown to return.
 func (a *Accepter) Shutdown(ctx context.Context) (err error) {
@@ -79,19 +79,19 @@ func (a *Accepter) Close() (err error) {
 	return
 }
 
-// TCPListenAndServe listens on the TCP network address addr and then calls
-// Serve to handle requests on incoming connections. TCPListenAndServe returns a
+// ListenAndServe listens on the given network and address; and then calls
+// Serve to handle incoming connections. ListenAndServe returns a
 // nil error after Close or Shutdown method called.
-func (a *Accepter) TCPListenAndServe(addr string) error {
-	l, err := net.Listen("tcp", addr)
+func (a *Accepter) ListenAndServe(network, address string) error {
+	lis, err := net.Listen(network, address)
 	if err != nil {
 		return err
 	}
-	return a.Serve(l)
+	return a.Serve(lis)
 }
 
-// TCPListenAndServeTLS listens on the TCP network address addr and
-// then calls Serve to handle requests on incoming TLS connections.
+// ListenAndServeTLS listens on the given network and address; and
+// then calls Serve to handle incoming TLS connections.
 //
 // Filenames containing a certificate and matching private key for the
 // Accepter must be provided if neither the Accepter's TLSConfig.Certificates
@@ -99,12 +99,12 @@ func (a *Accepter) TCPListenAndServe(addr string) error {
 // signed by a certificate authority, the certFile should be the
 // concatenation of the Accepter's certificate, any intermediates, and
 // the CA's certificate.
-func (a *Accepter) TCPListenAndServeTLS(addr string, certFile, keyFile string) error {
-	l, err := net.Listen("tcp", addr)
+func (a *Accepter) ListenAndServeTLS(network, address string, certFile, keyFile string) error {
+	lis, err := net.Listen(network, address)
 	if err != nil {
 		return err
 	}
-	return a.ServeTLS(l, certFile, keyFile)
+	return a.ServeTLS(lis, certFile, keyFile)
 }
 
 // Serve accepts incoming connections on the Listener lis, creating a new service
@@ -136,7 +136,7 @@ func (a *Accepter) Serve(lis net.Listener) (err error) {
 	}
 }
 
-// ServeTLS accepts incoming connections on the Listener l, creating a
+// ServeTLS accepts incoming connections on the Listener lis, creating a
 // new service goroutine for each. The service goroutines read requests and
 // then call a.Handler to reply to them. ServeTLS returns a nil error after
 // Close or Shutdown method called.
@@ -146,7 +146,7 @@ func (a *Accepter) Serve(lis net.Listener) (err error) {
 // nor TLSConfig.GetCertificate are populated. If the certificate is signed by
 // a certificate authority, the certFile should be the concatenation of the
 // Accepter's certificate, any intermediates, and the CA's certificate.
-func (a *Accepter) ServeTLS(l net.Listener, certFile, keyFile string) (err error) {
+func (a *Accepter) ServeTLS(lis net.Listener, certFile, keyFile string) (err error) {
 	var config *tls.Config
 	if a.TLSConfig != nil {
 		config = a.TLSConfig.Clone()
@@ -163,8 +163,7 @@ func (a *Accepter) ServeTLS(l net.Listener, certFile, keyFile string) (err error
 		}
 	}
 
-	tlsListener := tls.NewListener(l, config)
-	return a.Serve(tlsListener)
+	return a.Serve(tls.NewListener(lis, config))
 }
 
 func (a *Accepter) serve(conn net.Conn) {

--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"net"
 
@@ -11,18 +12,19 @@ import (
 
 func main() {
 	a := &accepter.Accepter{
-		Handler: accepter.HandlerFunc(func(conn net.Conn, closeCh <-chan struct{}) {
+		Handler: accepter.HandlerFunc(func(ctx context.Context, conn net.Conn) {
 			for {
-				var b [1]byte
+				var b [32 * 1024]byte
 				n, err := conn.Read(b[:])
 				if err != nil {
 					break
 				}
-				if n > 0 {
-					n, err := conn.Write(b[:])
-					if err != nil || n < 1 {
-						break
-					}
+				m, err := conn.Write(b[:n])
+				if err != nil {
+					break
+				}
+				if m < n {
+					break
 				}
 			}
 		}),

--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -29,5 +29,5 @@ func main() {
 			}
 		}),
 	}
-	log.Fatal(a.TCPListenAndServe(":1234"))
+	log.Fatal(a.ListenAndServe("tcp", ":1234"))
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/orkunkaraduman/go-accepter
+
+go 1.1

--- a/handler.go
+++ b/handler.go
@@ -1,18 +1,21 @@
 package accepter
 
-import "net"
+import (
+	"context"
+	"net"
+)
 
 // A Handler responds to an incoming connection.
 type Handler interface {
-	Serve(conn net.Conn, closeCh <-chan struct{})
+	Serve(ctx context.Context, conn net.Conn)
 }
 
 // The HandlerFunc type is an adapter to allow the use of ordinary functions as
 // handlers. If f is a function with the appropriate signature, HandlerFunc(f)
 // is a Handler that calls f.
-type HandlerFunc func(conn net.Conn, closeCh <-chan struct{})
+type HandlerFunc func(ctx context.Context, conn net.Conn)
 
-// Serve calls f(conn, closeCh)
-func (f HandlerFunc) Serve(conn net.Conn, closeCh <-chan struct{}) {
-	f(conn, closeCh)
+// Serve calls f(ctx, conn)
+func (f HandlerFunc) Serve(ctx context.Context, conn net.Conn) {
+	f(ctx, conn)
 }


### PR DESCRIPTION
- using cancelling context instead of channel
- changed Handler.Serve arguments to (ctx, conn) from (conn, closeCh)
- removed panic recovering for Handler.Serve(...)
- removed Accepter.ErrorLog
- added ListenAndServe and ListenAndServeTLS, removed TCPListenAndServe and TCPListenAndServeTLS
- added go.mod support
- added listener close in Serve